### PR TITLE
#40 extend member overview

### DIFF
--- a/server/src/members/membersController.ts
+++ b/server/src/members/membersController.ts
@@ -55,8 +55,9 @@ export const login = (req: Request, res: Response): void => {
  */
 export const retrieveMemberList = (req: Request, res: Response): void => {
   database.query(
-   `SELECT mitgliedID, nachname, vorname, handy, jbt_email, mitgliedstatus, ressort
+   `SELECT mitgliedID, nachname, vorname, handy, mitglied.jbt_email, mitgliedstatus, ressort.kuerzel AS ressort
    FROM mitglied
+   INNER JOIN ressort ON mitglied.ressort = ressort.ressortID
    ORDER BY nachname DESC`,
    [])
    .then((result: membersTypes.GetMembersQueryResult) => {

--- a/server/src/members/membersController.ts
+++ b/server/src/members/membersController.ts
@@ -55,7 +55,7 @@ export const login = (req: Request, res: Response): void => {
  */
 export const retrieveMemberList = (req: Request, res: Response): void => {
   database.query(
-   `SELECT mitgliedID, nachname, vorname, handy, mitgliedstatus
+   `SELECT mitgliedID, nachname, vorname, handy, jbt_email, mitgliedstatus, ressort
    FROM mitglied
    ORDER BY nachname DESC`,
    [])


### PR DESCRIPTION
Responded member overview data now contains internal email address and the 
abbreviation of the corresponding ressort

Fixes #40 