### PR TITLE
Added a global content root class

### DIFF
--- a/client/src/scss/app.scss
+++ b/client/src/scss/app.scss
@@ -24,3 +24,21 @@ body {
   height: 100%;
   width: 100%;
 }
+
+/*
+ * every page needs to have this class at its root in order to 
+ * display the content without it getting covered by the navigation
+ */
+.content-page {
+  flex-grow: 1;
+  padding: 5px;
+  margin-top: 58px;
+  @media only screen and (min-width: 960px){
+    margin-top: 65px;
+    margin-left: 287px;
+    margin-right: 7px;
+  }
+  @media only screen and (min-width: 600px){
+    margin-top: 65px;
+  }
+}

--- a/client/src/ts/members/MemberOverview.tsx
+++ b/client/src/ts/members/MemberOverview.tsx
@@ -33,19 +33,6 @@ import api from "../utils/api";
  * Function which proivdes the styles of the MemberOverview
  */
 const useStyles = makeStyles((theme: Theme) => createStyles({
-  memberOverviewRoot: {
-    flexGrow: 1,
-    padding: "5px",
-    marginTop: "58px",
-    [theme.breakpoints.up("md")]: {
-      marginTop: "65px",
-      marginLeft: "287px",
-      marginRight: "7px",
-    },
-    [theme.breakpoints.up("sm")]: {
-      marginTop: "65px",
-    },
-  },
   amountOfEntries: {
     marginBottom: "10px",
     padding: "7px",
@@ -407,7 +394,7 @@ const MemberOverview: React.FunctionComponent = () => {
   );
 
   return (
-      <div className={classes.memberOverviewRoot}>
+      <div className="content-page">
       <Paper className={classes.filterContainer}>
         <form className={classes.filters} noValidate autoComplete="off">
         <Grid container spacing={8}>


### PR DESCRIPTION
The styles to display the content without it getting covered by the navigation were moved to a global class.
Closes #58 