### PR TITLE
Fixed permissions bug

### DIFF
--- a/server/src/members/membersController.ts
+++ b/server/src/members/membersController.ts
@@ -19,7 +19,7 @@ export const login = (req: Request, res: Response): void => {
    database.query(
     `SELECT mitgliedID, name, passwordHash, GROUP_CONCAT(mitglied_has_berechtigung.berechtigung_berechtigungID) AS permissions
     FROM mitglied
-    INNER JOIN mitglied_has_berechtigung ON mitglied.mitgliedID = mitglied_has_berechtigung.mitglied_mitgliedID
+    LEFT JOIN mitglied_has_berechtigung ON mitglied.mitgliedID = mitglied_has_berechtigung.mitglied_mitgliedID
     WHERE mitglied.name = ?
     GROUP BY mitgliedID, name`,
     [req.body.username])
@@ -33,7 +33,7 @@ export const login = (req: Request, res: Response): void => {
           const payload: JWTPayload = {
             mitgliedID: result[0].mitgliedID,
             name: result[0].name,
-            permissions: result[0].permissions.split(",").map(Number)
+            permissions: result[0].permissions ? result[0].permissions.split(",").map(Number) : []
           };
           res.status(200).json({
             token: auth.generateJWT(payload),


### PR DESCRIPTION
Login would fail if an user had no permissions due to a faulty SQL join.
The INNER JOIN operation returns an empty result if one table has no
entries for a specified targed. Therefore it was necessary to use
LEFT JOIN so the results of the left table are still returned even if
the right table has no results

Fixes #39 