### PR TITLE
Changed start-script in package.json

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "ts-node-dev --respawn --transpileOnly ./src/server.ts",
+    "start": "ts-node-dev --respawn --transpile-only ./src/server.ts",
     "prod": "npm run build && npm run start",
     "lint": "tslint --project ./"
   }


### PR DESCRIPTION
Changed `transpileOnly` to `transpile-only` in "scripts" > "start" in package.json.
According to https://www.npmjs.com/package/ts-node-dev#usage this is the correct way of spelling this option.

Closes #72 